### PR TITLE
Add startup delay of 2 seconds

### DIFF
--- a/amsat-dl-upc/src/main.c
+++ b/amsat-dl-upc/src/main.c
@@ -156,6 +156,11 @@ void main(void)
     PIE1 = 0;
     PIE2 = 0;
 
+    for (int i=0; i<20; i++) {
+        CLRWDT();
+        __delay_ms(100);
+    }
+
     init_gpios();
 
     adc_init();


### PR DESCRIPTION
The up converter sends its config data right after startup. For some project (e.g. https://github.com/phl0/ConverterDisplay) this is too fast as the micro controller code is not up and running yet when this happens.
This patch adds a 2-second start-up delay to give the controller time to boot and be ready to receive the data.